### PR TITLE
1.0.1 release

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,7 +44,7 @@
 Bookmarks Plugin Changelog
 </h1>
 
-<p><b>1.0.1</b> -- (tbd)</p>
+<p><b>1.0.1</b> -- December 23, 2018</p>
 <ul>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1641'>OF-1641</a>] - Ensure all JSP pages have the correct contentType .</li>
     <li>[<a href='https://issues.igniterealtime.org/browse/OF-1517'>OF-1517</a>] - Don't require i18n source files for all plugins to be encoded.</li>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>tbc.</date>
+    <date>12/23/2018</date>
     <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>plugins</artifactId>
         <groupId>org.igniterealtime.openfire</groupId>
-        <version>4.3.0-SNAPSHOT</version>
+        <version>4.3.0-beta</version>
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <name>Bookmarks Plugin</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
     </build>
 
     <distributionManagement>
+        <!-- Repository in which we deploy this project, when desired. -->
         <repository>
             <id>igniterealtime</id>
             <name>Ignite Realtime Repository</name>
@@ -61,6 +62,7 @@
     </distributionManagement>
 
     <repositories>
+        <!-- Where we obtain dependencies. -->
         <repository>
             <id>igniterealtime</id>
             <name>Ignite Realtime Repository</name>
@@ -68,4 +70,14 @@
         </repository>
     </repositories>
 
+    <pluginRepositories>
+        <!-- Typically used to retrieve Maven plugins used by this project from. This
+             apparently is also used to obtain the dependencies _used by_ plugins
+             (eg: openfire-plugin-assembly-descriptor) -->
+        <pluginRepository>
+            <id>igniterealtime</id>
+            <name>Ignite Realtime Repository</name>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
+        </pluginRepository>
+    </pluginRepositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <name>Bookmarks Plugin</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <repository>
             <id>igniterealtime</id>
             <name>Ignite Realtime Repository</name>
-            <url>http://igniterealtime.org/archiva/repository/maven/</url>
+            <url>https://igniterealtime.org/archiva/repository/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This PR has three commits:

1. Parent project should not be a SNAPSHOT version (which would cause the enforcer plugin to prevent a release).
2. Denote the v1.0.1 release (by setting the version number of the project to a non-SNAPSHOT version).
3. Increment the version number to the next SNAPSHOT release.

I'm hoping that, upon merging this PR, Travis will build a SNAPSHOT release for at least commit 3 (maybe 1? probably not). Also, after merge, I'll manually set a tag/release in Github, which _should_ cause Travis to perform a proper (non-SNAPSHOT) release.

Here goes...