### PR TITLE
Release 1.1.1

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -44,6 +44,10 @@
 Bookmarks Plugin Changelog
 </h1>
 
+<p><b>1.1.2</b> -- tbd</p>
+<ul>
+</ul>
+
 <p><b>1.1.1</b> -- October 6, 2022</p>
 <ul>
     <li>Version bump to fix a metadata date issue in plugin.xml</li>

--- a/changelog.html
+++ b/changelog.html
@@ -44,8 +44,9 @@
 Bookmarks Plugin Changelog
 </h1>
 
-<p><b>1.1.1</b> -- tbc</p>
+<p><b>1.1.1</b> -- October 6, 2022</p>
 <ul>
+    <li>Version bump to fix a metadata date issue in plugin.xml</li>
 </ul>
 
 <p><b>1.1.0</b> -- March 4, 2022</p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -9,7 +9,7 @@
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
     <author>Ignite Realtime</author>
     <version>${project.version}</version>
-    <date>2022/03/04</date>
+    <date>2022-10-06</date>
     <minServerVersion>4.0.0</minServerVersion>
     <minJavaVersion>1.8</minJavaVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2-SNAPSHOT</version>
     <name>Bookmarks Plugin</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     </parent>
     <groupId>org.igniterealtime.openfire.plugins</groupId>
     <artifactId>bookmarks</artifactId>
-    <version>1.1.1-SNAPSHOT</version>
+    <version>1.1.1</version>
     <name>Bookmarks Plugin</name>
     <description>Allows clients to store URL and group chat bookmarks (XEP-0048)</description>
 


### PR DESCRIPTION
Present website code wants date in either yyyy-mm-dd or mm/dd/yyyy, so it was angry about yyyy/mm/dd.  Easier just to release this and move on as this plugin is the only one with this 'problem', I think.